### PR TITLE
Use default emptyDrops as backup

### DIFF
--- a/R/merge_utils.R
+++ b/R/merge_utils.R
@@ -1,10 +1,34 @@
-# samples_merge_list <- list(
-#   'SJIALD_20200716' = c('SJIALD_1-20200716_QC2.0', 'SJIALD_2-20200716_QC3'),
-#   'SJIALD_FID12518' = c('SJIALD_FID12518_Diseased_QC1.5', 'SJIALD_FID12518_Normal_QC3.5')
-# )
-
-# merge samples that are from the sample subject
-merge_samples <- function(data_dir, merge_list) {
+#' Merge samples that are from the sample subject
+#'
+#' @param subdirectory of single-cell
+#' @param merge_list Names are new name, values are current names to merge
+#' @param new_founder Name of new founder for dataset for grouping in select menu.
+#' Default (\code{NULL}) keeps previous founder.
+#'
+#' @return called for side effects
+#'
+#' @examples
+#'
+#' if (interactive()) {
+#'
+#'   dataset_names <- c('SJIALD_VS_HEALTHY_lungv1_merged_Azimuth',
+#'                      'SJIALD_VS_HEALTHY_merged_fastMNN')
+#'
+#'   merge_list <- list(
+#'     'SJIALD_20200716' = c('SJIALD_1-20200716_QC3.0', 'SJIALD_2-20200716_QC3.0'),
+#'     'SJIALD_FID12518' = c('SJIALD_FID12518_Diseased_QC2.0'))
+#'
+#'   new_founder <- 'SJIALD_VS_HEALTHY_merged'
+#'   sc_dir <- '~/Documents/Data/dseqr/cincinnati/sjiald-sc-lung/single-cell'
+#'
+#'   for (dataset_name in dataset_names) {
+#'     data_dir <- file.path(sc_dir, dataset_name)
+#'     merge_samples(data_dir, samples_merge_list, new_founder)
+#'   }
+#'
+#' }
+#'
+merge_samples <- function(data_dir, merge_list, new_founder = NULL) {
   # open shell and merge batch and ambience
   shell <- qs::qread(file.path(data_dir, 'shell.qs'))
   rdata <- SummarizedExperiment::rowData(shell)
@@ -38,6 +62,11 @@ merge_samples <- function(data_dir, merge_list) {
   resoln_basenames <- basename(resoln_files)
   keep <- resoln_basenames %in% c('annot.qs', 'clusters.qs')
   unlink(resoln_files[!keep])
+
+  # change founder
+  if (!is.null(new_founder)) {
+    qs::qsave(new_founder, file.path(data_dir, 'founder.qs'))
+  }
 }
 
 # merge clusters that want to analyze together

--- a/R/modules-sc-server.R
+++ b/R/modules-sc-server.R
@@ -4241,7 +4241,8 @@ get_scatter_props <- function(is_mobile, ncells) {
   scatter_props <- list(
     radiusMinPixels = pt.size,
     radiusMaxPixels = max(6, pt.size*2),
-    stroked = pt.size >= 3
+    stroked = pt.size >= 3,
+    lineWidthMaxPixels = 1
   )
 
   return(scatter_props)
@@ -4564,6 +4565,7 @@ scViolinPlot <- function(input, output, session, selected_gene, selected_cluster
 
     h5logs <- if (is.gene) h5logs() else NULL
     if (is.null(scseq)) return(NULL)
+
     vdat <- get_violin_data(gene, scseq, cluster, with_all = TRUE, h5logs=h5logs)
 
     return(vdat)

--- a/R/plot_scseq.R
+++ b/R/plot_scseq.R
@@ -80,9 +80,9 @@ get_violin_data <- function(feature, scseq, selected_cluster, by.sample = FALSE,
 
   # either highlight test group or selected cluster
   if (by.sample) {
-    keep <- scseq$cluster %in% sel
-    y <- factor(scseq$batch[keep])
-    hl <- scseq$orig.ident[keep]
+    keep.cells <- scseq$cluster %in% sel
+    y <- factor(scseq$batch[keep.cells])
+    hl <- scseq$orig.ident[keep.cells]
 
     # cluster name get's appended by VlnPlot
     title <- paste(title.type, 'by Sample:', feature, 'in')
@@ -103,7 +103,8 @@ get_violin_data <- function(feature, scseq, selected_cluster, by.sample = FALSE,
     } else {
       x <- as.numeric(SingleCellExperiment::logcounts(scseq[feature, ]))
     }
-    if (exists('keep')) x <- x[keep]
+
+    if ('keep.cells' %in% ls()) x <- x[keep.cells]
 
   } else {
     x <- scseq[[feature]]

--- a/R/scseq_qc.R
+++ b/R/scseq_qc.R
@@ -15,7 +15,15 @@ detect_cells <- function(counts, qcgenes) {
   e.out <- DropletUtils::emptyDrops(counts[keep.genes, ], retain = Inf)
 
   keep.cells <- which(e.out$FDR <= 0.001)
-  if (!length(keep.cells)) stop('No non-empty cells')
+
+  if (!length(keep.cells)) {
+    warning('emptyDrops detected no non-empty cells. Trying again with default arguments.')
+    e.out <- DropletUtils::emptyDrops(counts)
+    keep.cells <- which(e.out$FDR <= 0.001)
+
+    if (!length(keep.cells))
+      stop('emptyDrops and defaultDrops detects no non-empty cells.')
+  }
 
   return(keep.cells)
 }

--- a/R/scseq_qc.R
+++ b/R/scseq_qc.R
@@ -13,7 +13,9 @@ detect_cells <- function(counts, qcgenes) {
 
   set.seed(100)
   e.out <- DropletUtils::emptyDrops(counts[keep.genes, ], retain = Inf)
+
   keep.cells <- which(e.out$FDR <= 0.001)
+  if (!length(keep.cells)) stop('No non-empty cells')
 
   return(keep.cells)
 }


### PR DESCRIPTION
[This sample](https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSM5676979) failed to find any non-empty droplets with the current arguments used for `emptyDrops` (excluding mito/ribo genes, and `retain=Inf`). For these cases, will try the default arguments.