### PR TITLE
fix safari uploads

### DIFF
--- a/R/modules-bulk-server.R
+++ b/R/modules-bulk-server.R
@@ -1403,12 +1403,10 @@ bulkAnnot <- function(input, output, session, dataset_name, annot) {
 
 
   observeEvent(input$click_up, {
-    shinyjs::click('up_annot')
     error_msg(NULL)
   })
 
   observeEvent(input$click_dl, {
-    shinyjs::click('dl_annot')
     error_msg(NULL)
   })
 

--- a/R/modules-bulk-ui.R
+++ b/R/modules-bulk-ui.R
@@ -52,21 +52,75 @@ bulkAnnotInput <- function(id) {
   ns <- NS(id)
   tagList(
     tags$div(id=ns('validate-up'), class='validate-wrapper',
-             shinyWidgets::actionGroupButtons(
+             actionGroupButtonsWithClickHandlers(
                inputIds = c(ns('click_dl'), ns('click_up')),
+               onclicks = c(sprintf('$("#%s").click()', ns('dl_annot')),
+                            sprintf('$("#%s").click()', ns('up_annot'))),
                labels = list(icon('download', 'fa-fw'), icon('upload', 'fa-fw'))
              ),
              tags$div(class='help-block', id = ns('error_msg'))
 
     ),
     # hidden dl/upload buttons
-    div(style = 'display: none',
+    div(style = 'display: none;',
         fileInput(ns('up_annot'), '', accept = c("text/csv", "text/comma-separated-values,text/plain", ".csv")),
     ),
     downloadLink(ns('dl_annot'), ''),
 
     shinyBS::bsTooltip(id = ns('click_dl'), title = 'Download metadata to fill: <b>Group name</b> and <b>Pair</b> (optional)', options = list(container = 'body')),
     shinyBS::bsTooltip(id = ns('click_up'), title = 'Upload filled metadata', options = list(container = 'body'))
+  )
+}
+
+actionGroupButtonsWithClickHandlers <- function(inputIds,
+                                                labels,
+                                                onclicks,
+                                                status = "default",
+                                                size = "normal",
+                                                direction = "horizontal",
+                                                fullwidth = FALSE) {
+  stopifnot(length(inputIds) == length(labels))
+  size <- match.arg(
+    arg = size,
+    choices = c("xs", "sm", "normal", "lg")
+  )
+  direction <- match.arg(
+    arg = direction,
+    choices = c("horizontal", "vertical")
+  )
+  status <- rep(status, length.out = length(labels))
+  tags$div(
+    class = "btn-group",
+    class = if (direction == "vertical") "btn-group-vertical",
+    class = paste0("btn-group-", size),
+    class = if(fullwidth) "btn-group-justified",
+    role = "group",
+    lapply(
+      X = seq_along(labels),
+      FUN = function(i) {
+        value <- shiny::restoreInput(id = inputIds[i], default = NULL)
+        if (fullwidth) {
+          tags$div(
+            class = "btn-group", role = "group",
+            class = paste0("btn-group-", size),
+            tags$button(
+              id = inputIds[i],
+              type = "button",`data-val` = value,
+              class = paste0("btn action-button btn-", status[i]),
+              labels[i]
+            )
+          )
+        } else {
+          tags$button(
+            id = inputIds[i],
+            type = "button",`data-val` = value,
+            class = paste0("btn action-button btn-", status[i]),
+            onclick = onclicks[i],
+            labels[i]
+          )
+        }
+      }
+    )
   )
 }
 

--- a/R/modules-drugs-server.R
+++ b/R/modules-drugs-server.R
@@ -160,18 +160,14 @@ customQueryForm <- function(input, output, session, show_custom, is_custom, anal
     shinyjs::toggleClass('validate', 'has-error', condition = isTruthy(msg))
   })
 
+  observe(shinyjs::toggleState('click_custom', condition = isTruthy(input$custom_name)))
+
   observeEvent(input$click_custom, {
-    if (!isTruthy(input$custom_name)) {
-      error_msg('Need name for query')
-      return(NULL)
-    }
     error_msg(NULL)
-    shinyjs::click('up_custom')
   })
 
 
   observeEvent(input$up_custom, {
-
 
     infile <- input$up_custom
     if (!isTruthy(infile)){

--- a/R/modules-drugs-ui.R
+++ b/R/modules-drugs-ui.R
@@ -132,7 +132,10 @@ customQueryFormInput <- function(id) {
            shinypanel::textInputWithButtons(
              inputId = ns('custom_name'),
              label = 'Name for custom query:',
-             actionButton(ns('click_custom'), '', icon('upload', 'fa-fw'), title = 'Upload csv with gene names and effect size'),
+             actionButton(ns('click_custom'), '',
+                          icon('upload', 'fa-fw'),
+                          title = 'Upload csv with gene names and effect size',
+                          onclick = sprintf('$("#%s").click()', ns('up_custom'))),
              container_id = ns('validate'),
              help_id = ns('error_msg')),
 

--- a/inst/app/server.R
+++ b/inst/app/server.R
@@ -130,19 +130,6 @@ server <- function(input, output, session) {
     rintrojs::introjs(session, options = list(showStepNumbers = 'false', steps = steps))
   })
 
-  observe({
-    if (length(list.dirs(sc_dir(), recursive = FALSE))) return(NULL)
-    # show hints and add dataset modal if no datasets
-    shinyjs::click('add_dataset')
-    rintrojs::hintjs(session,
-                     options = list(hints =
-                                      data.frame(
-                                        element = '#docs-link',
-                                        hint = 'Read the docs for all the details.',
-                                        hintPosition = 'middle-middle')))
-  })
-
-
   # customize dataset management dropdown for each tab
   observe({
     toggle('tour_dropdown', condition = input$tab == 'Single Cell')

--- a/inst/app/tests/testthat/test-shinytest2.R
+++ b/inst/app/tests/testthat/test-shinytest2.R
@@ -59,6 +59,7 @@ test_that("{shinytest2} recording: Single-Cell Tab", {
   on.exit(app$stop(), add = TRUE)
 
 
+  app$click("add_dataset")
   app$upload_file(`sc-form-dataset-up_raw` = file.path(sample_dir, "barcodes.tsv.gz"))
   app$upload_file(`sc-form-dataset-up_raw` = file.path(sample_dir, "genes.tsv.gz"))
   app$upload_file(`sc-form-dataset-up_raw` = file.path(sample_dir, "matrix.mtx.gz"))


### PR DESCRIPTION
Safari uploads can not be triggered through `shinyjs::click` so they were moved to an `onclick` handler.

This PR also stops the single-cell upload modal from displaying when there is no SC data.