### PR TITLE
push buildcache before tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Build and export to Docker
+      - name: Build Docker image
         uses: docker/build-push-action@v3
         with:
           context: .
@@ -37,6 +37,13 @@ jobs:
           load: true
           cache-from: type=registry,ref=${{ env.DOCKERHUB_REPO }}:buildcache
           tags: ${{ env.DOCKERHUB_REPO }}:testing
+
+      # push cache that includes production and testing
+      - name: Push buildcache to DockerHub
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          cache-to: type=registry,ref=${{ env.DOCKERHUB_REPO }}:buildcache,mode=max
 
       - name: Test pull request
         if: github.event.pull_request.merged == false
@@ -52,11 +59,4 @@ jobs:
           push: true
           tags: ${{ env.DOCKERHUB_REPO }}:latest
 
-      # push cache that includes production and testing
-      - name: Push buildcache to DockerHub on merge
-        uses: docker/build-push-action@v2
-        if: github.event.pull_request.merged == true
-        with:
-          context: .
-          cache-to: type=registry,ref=${{ env.DOCKERHUB_REPO }}:buildcache,mode=max
 


### PR DESCRIPTION
makes it so that don't need to repeatedly rebuild if tests fail